### PR TITLE
Add support for defining includes in protobuild.yml that are passed t…

### DIFF
--- a/src/proto_task.py
+++ b/src/proto_task.py
@@ -53,6 +53,13 @@ class ProtoTask:
         gen_transport = config['transport']
         options = [path_to_proto_compiler, f'-I={include_dir}']
 
+        # s6fix @bernst - Allow an includes list in the protobuild.yml file to forward include directories for protoc to search.
+        if config['includes'] is not None:
+            for include in config['includes']:
+                include_adj = PathConverter.to_absolute(proto_root, include)
+                options.append(f'-I={include_adj}')
+        # s6fix_end
+
         path_to_plugin = os.path.join(programs_root, Misc.add_exec_suffix(Misc.plugin_for_lang(self.lang)))
 
         if 'protoc_options' in config.options.keys():

--- a/src/proto_task.py
+++ b/src/proto_task.py
@@ -53,12 +53,10 @@ class ProtoTask:
         gen_transport = config['transport']
         options = [path_to_proto_compiler, f'-I={include_dir}']
 
-        # s6fix @bernst - Allow an includes list in the protobuild.yml file to forward include directories for protoc to search.
         if config['includes'] is not None:
             for include in config['includes']:
                 include_adj = PathConverter.to_absolute(proto_root, include)
                 options.append(f'-I={include_adj}')
-        # s6fix_end
 
         path_to_plugin = os.path.join(programs_root, Misc.add_exec_suffix(Misc.plugin_for_lang(self.lang)))
 

--- a/src/proto_task.py
+++ b/src/proto_task.py
@@ -13,6 +13,9 @@
 # License for the specific language governing permissions and limitations
 # under the License.
 #
+
+# Modified 2021 by Singularity 6, Inc.
+
 import os
 
 from colorama import Fore


### PR DESCRIPTION
Add support for defining **includes** in `protobuild.yml` that are passed to `protoc`.

Allows you to have `protobuild.yml` that contains, or what have you:
```
includes:
 - '../../include'
 - '../com.s6.core'
```