### PR TITLE
Allow Protobuild to work on newer version of PyYaml.

### DIFF
--- a/src/config.py
+++ b/src/config.py
@@ -94,5 +94,5 @@ class Config:
     @staticmethod
     def load(path: str):
         with open(path, 'r') as stream:
-            yaml_config = yaml.load(stream)
+            yaml_config = yaml.safe_load(stream)
             return Config(path, yaml_config)


### PR DESCRIPTION
In the newer version of PyYaml the function "load" needs the Loader specified, or you can use the function "safe_load".

Things worked on Python 3.8.1 for me. We started running into issues on Python 3.8.2. And I reproduced the issue on 3.10.0. I was tipped off to the PyYaml version issue here: https://stackoverflow.com/a/69581453